### PR TITLE
Fix App#pack_build with no block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## 0.1.1
+
+- Fix App#pack_build with no block https://github.com/heroku/cutlass/pull/3
+
 ## [0.1.0] - 2021-03-29
 
 - Initial release

--- a/lib/cutlass/app.rb
+++ b/lib/cutlass/app.rb
@@ -110,7 +110,9 @@ module Cutlass
       on_teardown { build.teardown }
 
       @builds << build
-      yield build.call
+      build.call
+
+      yield build if block_given?
     end
 
     def transaction

--- a/lib/cutlass/version.rb
+++ b/lib/cutlass/version.rb
@@ -2,5 +2,5 @@
 
 module Cutlass
   # Version
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/unit/app_spec.rb
+++ b/spec/unit/app_spec.rb
@@ -54,9 +54,13 @@ module Cutlass
             web: touch lol && tail -f lol # Need an entrypoint that doesn't exit
           EOM
 
+          # Test build with block
           app.pack_build do |result|
             expect(result.stdout).to include("Successfully built image")
           end
+
+          # Test build with no block
+          app.pack_build
 
           # App#stdout is the same as App#last_build.stdout
           expect(app.stdout).to include("Successfully built image")


### PR DESCRIPTION
Yield will error if no block is given. This PR allows `pack_build` to be called without a block.