### PR TITLE
Shortcut for using default buildpacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## 0.1.2
+
+- App.new accepts a buildpack array with the `:default` symbol which acts as a shortcut for `Cutlass.default_buildpack_paths` https://github.com/heroku/cutlass/pull/4
+- `Cutlass.default_buildpack_paths=` raises an error if you pass in a path that does not exist. https://github.com/heroku/cutlass/pull/4
+
 ## 0.1.1
 
 - Fix App#pack_build with no block https://github.com/heroku/cutlass/pull/3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cutlass (0.1.1)
+    cutlass (0.1.2)
       docker-api (>= 2.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ In additon to the standard `package.toml` interface, if this directory has a `bu
 
 - @param repo_name [String] the path to a directory on disk, or the name of a directory inside of the `config.default_repos_dir`.
 - @param builder [String] the name of a CNB "builder" used to build the app against. Defaults to `config.default_builder`.
-- @param buildpacks [Array<String>] the array of buildpacks to build the app against. Defaults to `config.default_buildpack_paths`.
+- @param buildpacks [Array<String>] the array of buildpacks to build the app against. Defaults to `config.default_buildpack_paths`. If you pass in a symbol of `:default` it will substitute `Cutlass.default_buildpack_paths`. That means passing in `["heroku/nodejs", :default]` is a shortcut for `["heroku/nodejs, Cutlass.default_buildpack_paths].flatten`.
 - @param config [Hash{Symbol => String}, Hash{String => String}] env vars to set against the app before it is built.
 - @param exception_on_failure: [Boolean] when truthy failures on `app.pack_build` will result in an exception. Default is true.
 

--- a/lib/cutlass.rb
+++ b/lib/cutlass.rb
@@ -20,8 +20,23 @@ module Cutlass
 
   class << self
     # Cutlass.default_builder
-    # Cutlass.default_buildpack_paths
-    attr_accessor :default_builder, :default_buildpack_paths
+    attr_accessor :default_builder
+  end
+
+  def self.default_buildpack_paths=(paths)
+    paths = Array(paths).map { |path| Pathname(path) }
+
+    paths.each do |path|
+      raise "Path must exist on disk #{path}" unless path.exist?
+    end
+
+    @default_buildpack_paths = paths
+  end
+
+  def self.default_buildpack_paths
+    raise "Must set Cutlass.default_buildpack_paths to a non-empty value" if @default_buildpack_paths.empty? || @default_buildpack_paths.nil?
+
+    @default_buildpack_paths
   end
 
   @default_buildpack_paths = []

--- a/lib/cutlass/app.rb
+++ b/lib/cutlass/app.rb
@@ -34,7 +34,7 @@ module Cutlass
       @warn_io = warn_io
       @builder = builder
       @image_name = image_name
-      @buildpacks = buildpacks
+      @buildpacks = Array(buildpacks).map { |buildpack| buildpack == :default ? Cutlass.default_buildpack_paths : buildpack }.flatten
       @source_path_name = source_path_name
       @exception_on_failure = exception_on_failure
     end

--- a/lib/cutlass/version.rb
+++ b/lib/cutlass/version.rb
@@ -2,5 +2,5 @@
 
 module Cutlass
   # Version
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/unit/cutlass_module_spec.rb
+++ b/spec/unit/cutlass_module_spec.rb
@@ -3,16 +3,18 @@
 module Cutlass
   RSpec.describe Cutlass do
     it "is configurable" do
-      Cutlass.in_fork do
-        Cutlass.config do |config|
-          config.default_builder = "foo/bar"
-          config.default_repo_dirs = ["foo"]
-          config.default_buildpack_paths = ["bar"]
-        end
+      Dir.mktmpdir do |dir|
+        Cutlass.in_fork do
+          Cutlass.config do |config|
+            config.default_builder = "foo/bar"
+            config.default_repo_dirs = ["foo"]
+            config.default_buildpack_paths = [dir]
+          end
 
-        expect(Cutlass.default_builder).to eq("foo/bar")
-        expect(Cutlass.default_repo_dirs.map(&:to_s)).to eq(["foo"])
-        expect(Cutlass.default_buildpack_paths).to eq(["bar"])
+          expect(Cutlass.default_builder).to eq("foo/bar")
+          expect(Cutlass.default_repo_dirs.map(&:to_s)).to eq(["foo"])
+          expect(Cutlass.default_buildpack_paths.map(&:to_s)).to eq([dir])
+        end
       end
     end
 


### PR DESCRIPTION
- App.new accepts a buildpack array with the `:default` symbol which acts as a shortcut for `Cutlass.default_buildpack_paths`
- `Cutlass.default_buildpack_paths=` raises an error if you pass in a path that does not exist.