### PR TITLE
Don't connect to docker if it's not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## 0.1.3
+
+- Do not connect to docker if it's not needed https://github.com/heroku/cutlass/pull/5
+
 ## 0.1.2
 
 - App.new accepts a buildpack array with the `:default` symbol which acts as a shortcut for `Cutlass.default_buildpack_paths` https://github.com/heroku/cutlass/pull/4

--- a/lib/cutlass/clean_test_env.rb
+++ b/lib/cutlass/clean_test_env.rb
@@ -35,9 +35,9 @@ module Cutlass
       @skip_keys << key
     end
 
-    def self.record
+    def self.record(docker: ENV["CUTLASS_CHECK_DOCKER"])
       @env_diff = EnvDiff.new(skip_keys: @skip_keys)
-      @docker_diff = DockerDiff.new
+      @docker_diff = DockerDiff.new if docker
     end
 
     def self.check(docker: ENV["CUTLASS_CHECK_DOCKER"])

--- a/spec/unit/clean_test_env_spec.rb
+++ b/spec/unit/clean_test_env_spec.rb
@@ -29,7 +29,7 @@ module Cutlass
         Cutlass.in_fork do
           image_name = "cutlass_#{SecureRandom.hex(10)}:sup"
 
-          CleanTestEnv.record
+          CleanTestEnv.record(docker: true)
           dir = Pathname(dir)
           dockerfile = dir.join("Dockerfile")
           dockerfile.write <<~EOM


### PR DESCRIPTION
This code may be used in a CI suite where some tests don't need docker and so it may not be present. If the docker check feature is disabled, don't attempt to connect to docker.