### PR TITLE
Allows setting config to LocalBuildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## 0.1.4
+
+- Cutlass.default_buildpack_paths= now accepts a LocalBuildpack https://github.com/heroku/cutlass/pull/6
+
 ## 0.1.3
 
 - Do not connect to docker if it's not needed https://github.com/heroku/cutlass/pull/5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cutlass (0.1.2)
+    cutlass (0.1.4)
       docker-api (>= 2.0)
 
 GEM

--- a/lib/cutlass.rb
+++ b/lib/cutlass.rb
@@ -24,7 +24,7 @@ module Cutlass
   end
 
   def self.default_buildpack_paths=(paths)
-    paths = Array(paths).map { |path| Pathname(path) }
+    paths = Array(paths).map { |path| path.respond_to?(:exist?) ? path : Pathname(path) }
 
     paths.each do |path|
       raise "Path must exist on disk #{path}" unless path.exist?

--- a/lib/cutlass/local_buildpack.rb
+++ b/lib/cutlass/local_buildpack.rb
@@ -31,6 +31,10 @@ module Cutlass
       @image_name = "cutlass_local_buildpack_#{SecureRandom.hex(10)}"
     end
 
+    def exist?
+      @directory.exist?
+    end
+
     def teardown
       return unless built?
 

--- a/lib/cutlass/version.rb
+++ b/lib/cutlass/version.rb
@@ -2,5 +2,5 @@
 
 module Cutlass
   # Version
-  VERSION = "0.1.2"
+  VERSION = "0.1.4"
 end

--- a/spec/unit/cutlass_module_spec.rb
+++ b/spec/unit/cutlass_module_spec.rb
@@ -18,6 +18,19 @@ module Cutlass
       end
     end
 
+    it "accepts a local buildpack" do
+      Dir.mktmpdir do |dir|
+        Cutlass.in_fork do
+          buildpack = LocalBuildpack.new(directory: dir)
+          Cutlass.config do |config|
+            config.default_buildpack_paths = [buildpack]
+          end
+        ensure
+          buildpack&.teardown
+        end
+      end
+    end
+
     it "resolves directories" do
       Cutlass.in_fork do
         Dir.mktmpdir do |dir|


### PR DESCRIPTION
I added in error handling for the case where an incorrect directory is passed in, but forgot the case where another object such as LocalBuildpack can be used.