### PR TITLE
Expect build.sh scripts to generate a target dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## 0.1.5
+
+- Expect build.sh scripts to produce a directory named "target" https://github.com/heroku/cutlass/pull/7
+
 ## 0.1.4
 
 - Cutlass.default_buildpack_paths= now accepts a LocalBuildpack https://github.com/heroku/cutlass/pull/6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cutlass (0.1.4)
+    cutlass (0.1.5)
       docker-api (>= 2.0)
 
 GEM

--- a/lib/cutlass/local_buildpack.rb
+++ b/lib/cutlass/local_buildpack.rb
@@ -90,7 +90,11 @@ module Cutlass
       puts result.stdout if Cutlass.debug?
       puts result.stderr if Cutlass.debug?
 
-      return if result.success?
+      if result.success?
+        @directory = @directory.join("target")
+        raise "Expected #{build_sh} to produce a directory #{@directory} but it did not" unless @directory.exist?
+        return
+      end
 
       raise <<~EOM
         Buildpack build step failed!

--- a/lib/cutlass/version.rb
+++ b/lib/cutlass/version.rb
@@ -2,5 +2,5 @@
 
 module Cutlass
   # Version
-  VERSION = "0.1.4"
+  VERSION = "0.1.5"
 end

--- a/spec/unit/local_buildpack_spec.rb
+++ b/spec/unit/local_buildpack_spec.rb
@@ -6,11 +6,12 @@ module Cutlass
       Dir.mktmpdir do |dir|
         name = SecureRandom.hex(10)
         dir = Pathname(dir)
-        dir.join("package.toml").write(<<~EOM)
+        dir.join("target").mkpath
+        dir.join("target/package.toml").write(<<~EOM)
           [buildpack]
           uri = "."
         EOM
-        dir.join("buildpack.toml").write(<<~EOM)
+        dir.join("target/buildpack.toml").write(<<~EOM)
           [buildpack]
           id = "cutlass/supreme_#{name}"
           version = "0.0.1"


### PR DESCRIPTION
When a `build.sh` script is present it is expected to generate a ./target directory and that target directory is expected to be used as the buildpack. This is present in the reference implementation https://github.com/heroku/buildpacks-jvm/blob/8ac7ba3a2607b0b6fcf20da15437470dc9a55512/test/rapier/rapier.rb#L39.