### PR TITLE
Process lock LocalBuildpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## [Unreleased]
 
+- Lock LocalBuildpack when generating images to prevent process race conditions https://github.com/heroku/cutlass/pull/9
+
 ## 0.1.6
 
-- Remove premature error checking from Cutlass.default_buildpack_paths
+- Remove premature error checking from Cutlass.default_buildpack_paths https://github.com/heroku/cutlass/pull/8
 
 ## 0.1.5
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cutlass (0.1.6)
+    cutlass (0.1.7)
       docker-api (>= 2.0)
 
 GEM

--- a/lib/cutlass/version.rb
+++ b/lib/cutlass/version.rb
@@ -2,5 +2,5 @@
 
 module Cutlass
   # Version
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
If a LocalBuildpack instance is shared between multiple threads or processes it will attempt to produce an image with the same name but it will error out. We can prevent that by generating a temp file and taking out a lock on it. This lock is visible across all processes and is atomic. Locking a file in this way prevents multiple buildpacks with the same name from being built by pack at the same time.