### PR TITLE
[changelog skip][close #15] ProcessStatus#to_i should be #exitstatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## 0.2.1
+
+- Fix incorrect conversion of a ProcessStatus into an exit code https://github.com/heroku/cutlass/pull/16
+
 ## 0.2.0
 
 - Allow exercising salesforce functions via FunctionQuery (Experimental API) https://github.com/heroku/cutlass/pull/10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cutlass (0.2.0)
+    cutlass (0.2.1)
       docker-api (>= 2.0)
 
 GEM

--- a/lib/cutlass/bash_result.rb
+++ b/lib/cutlass/bash_result.rb
@@ -28,7 +28,7 @@ module Cutlass
     def initialize(stdout:, stderr:, status:)
       @stdout = stdout
       @stderr = stderr
-      @status = status.to_i
+      @status = status.respond_to?(:exitstatus) ? status.exitstatus : status.to_i
     end
 
     # @return [Boolean]

--- a/lib/cutlass/version.rb
+++ b/lib/cutlass/version.rb
@@ -2,5 +2,5 @@
 
 module Cutlass
   # Version
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/unit/bash_result_spec.rb
+++ b/spec/unit/bash_result_spec.rb
@@ -26,6 +26,22 @@ module Cutlass
       )
       expect(result.success?).to be_truthy
 
+      `exit 0`
+      result = BashResult.new(
+        stdout: "",
+        stderr: "",
+        status: $?
+      )
+      expect(result.success?).to be_truthy
+
+      `exit 1`
+      result = BashResult.new(
+        stdout: "",
+        stderr: "",
+        status: $?
+      )
+      expect(result.success?).to be_falsey
+
       result = BashResult.new(
         stdout: "",
         stderr: "",


### PR DESCRIPTION
I would think that calling `to_i` on the global `$?` status object would return the same value as it's exit status, but that is not the case

```
irb(main):006:0> `ls /no/such/dir`
ls: /no/such/dir: No such file or directory
=> ""
irb(main):007:0> puts $?
pid 85171 exit 1
=> nil
irb(main):008:0> puts $?.exitstatus
1
=> nil
irb(main):009:0> puts $?.to_i
256
```

This needs to be updated

https://github.com/heroku/cutlass/blob/313bf47448011863a77acccb380502d9953c69cb/lib/cutlass/bash_result.rb#L31