### PR TITLE
When a query to a function fails right now cutlass does not emit very…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add debug log when a function query fails https://github.com/heroku/cutlass/pull/17
+
 ## 0.2.1
 
 - Fix incorrect conversion of a ProcessStatus into an exit code https://github.com/heroku/cutlass/pull/16


### PR DESCRIPTION
## Description

When a query to a function fails right now cutlass does not emit very useful debug information:

```
  1) Heroku's Nodejs CNB generates a callable salesforce function
     Failure/Error: expect(query.as_json).to eq("hello world")

     JSON::ParserError:
       message 809: unexpected token at 'Could not parse CloudEvent: Unexpected token a in JSON at position 0'

       boot stdout:
       boot stderr:
```

This PR adds debug information from the server including body, headers, and url decoding the extra info header:


```
$ rspec test/specs/node-function/cutlass_function_spec.rb; notify
Body: Could not parse CloudEvent: Unexpected token a in JSON at position 0
Code: 400
Headers: {"x-extra-info"=>"%7B%22requestId%22:%22n/a%22,%22source%22:%22n/a%22,%22execTimeMs%22:0,%22isFunctionError%22:false,%22stacktrace%22:%22%22,%22statusCode%22:400%7D", "content-type"=>"application/json; charset=utf-8", "content-length"=>"68", "Date"=>"Tue, 25 May 2021 18:54:17 GMT", "Connection"=>"keep-alive", "Keep-Alive"=>"timeout=5"}
x-extra-info: {"requestId":"n/a","source":"n/a","execTimeMs":0,"isFunctionError":false,"stacktrace":"","statusCode":400}
F

Failures:

  1) Heroku's Nodejs CNB generates a callable salesforce function
     Failure/Error: expect(query.as_json).to eq("hello world")

     JSON::ParserError:
       message 809: unexpected token at 'Could not parse CloudEvent: Unexpected token a in JSON at position 0'

       boot stdout:
       boot stderr:
```


## Impact

None/Low

## How is this tested

Exercised via unit tests