### PR TITLE
Add :memory option for controlling container max memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [Unreleased]
 
+- Support :memory option for start_container https://github.com/heroku/cutlass/pull/27
 - Add debug log when a function query fails https://github.com/heroku/cutlass/pull/17
 
 ## 0.2.1

--- a/lib/cutlass/app.rb
+++ b/lib/cutlass/app.rb
@@ -90,10 +90,10 @@ module Cutlass
       on_teardown { thread.join }
     end
 
-    def start_container(expose_ports: [])
+    def start_container(opts = {})
       raise "No block given" unless block_given?
 
-      ContainerBoot.new(image_id: last_build.image_id, expose_ports: expose_ports).call do |container|
+      ContainerBoot.new(opts.merge(image_id: last_build.image_id)).call do |container|
         yield container
       end
     end

--- a/lib/cutlass/container_boot.rb
+++ b/lib/cutlass/container_boot.rb
@@ -33,7 +33,7 @@ module Cutlass
   # container. It does not execute the container's entrypoint. That means if you're running
   # inside of a CNB image, that env vars won't be set and the directory might be different.
   class ContainerBoot
-    def initialize(image_id:, expose_ports: [])
+    def initialize(image_id:, expose_ports: [], memory: nil)
       @expose_ports = Array(expose_ports)
       config = {
         "Image" => image_id,
@@ -52,6 +52,7 @@ module Cutlass
         port_bindings["#{port}/tcp"] = [{"HostPort" => ""}]
       end
 
+      config.merge!("Memory" => memory.to_i) if memory
       @container = Docker::Container.create(config)
     end
 

--- a/lib/cutlass/container_boot.rb
+++ b/lib/cutlass/container_boot.rb
@@ -52,7 +52,7 @@ module Cutlass
         port_bindings["#{port}/tcp"] = [{"HostPort" => ""}]
       end
 
-      config.merge!("Memory" => memory.to_i) if memory
+      config["Memory"] = memory.to_i if memory
       @container = Docker::Container.create(config)
     end
 


### PR DESCRIPTION
If you don't specify the memory limit for a docker container, it gets the same limit as the host. This could mean that a greedy container being tested would be fighting with the actual test.

This change gives test authors an opportunity to limit the container with something like:

```ruby
app.start_container(expose_ports: 8080, memory: 1e9) do |container|
  # ...doing stuff
end
```
