### PR TITLE
Exercise memory codepath in a test

### DIFF
--- a/lib/cutlass/app.rb
+++ b/lib/cutlass/app.rb
@@ -90,10 +90,10 @@ module Cutlass
       on_teardown { thread.join }
     end
 
-    def start_container(opts = {})
+    def start_container(memory: nil, expose_ports: [])
       raise "No block given" unless block_given?
 
-      ContainerBoot.new(opts.merge(image_id: last_build.image_id)).call do |container|
+      ContainerBoot.new(image_id: last_build.image_id, memory: memory, expose_ports: expose_ports).call do |container|
         yield container
       end
     end

--- a/spec/unit/container_control_spec.rb
+++ b/spec/unit/container_control_spec.rb
@@ -45,6 +45,11 @@ module Cutlass
 
           expect(container.get_file_contents("foo.txt").strip).to eq("lol")
         end
+
+        ContainerBoot.new(image_id: image.id, expose_ports: [8080], memory: 1e9).call do |container|
+          container.bash_exec("touch haha")
+          expect(container.contains_file?("haha")).to be_truthy
+        end
       rescue => error
         raise error, <<~EOM
           #{error.message}


### PR DESCRIPTION
- Add a test that exercises the memory kwarg,
- Be explicit passing kwargs