### PR TITLE
Expose logs from running container instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## 0.2.4
+
+- Expose container logs on actively running instances via ContainerControl https://github.com/heroku/cutlass/pull/29
+
 ## 0.2.3
 
 - Fix keyword arg warning https://github.com/heroku/cutlass/pull/28

--- a/lib/cutlass/container_control.rb
+++ b/lib/cutlass/container_control.rb
@@ -14,6 +14,13 @@ module Cutlass
       @ports = ports
     end
 
+    def logs
+      stdout = @container.logs(stdout: 1)
+      stderr = @container.logs(stderr: 1)
+
+      BashResult.new(stdout: stdout, stderr: stderr, status: 0)
+    end
+
     def get_host_port(port)
       raise "Port not bound inside container: #{port}, bound ports: #{@ports.inspect}" unless @ports.include?(port)
       @container.json["NetworkSettings"]["Ports"]["#{port}/tcp"][0]["HostPort"]

--- a/lib/cutlass/version.rb
+++ b/lib/cutlass/version.rb
@@ -2,5 +2,5 @@
 
 module Cutlass
   # Version
-  VERSION = "0.2.3"
+  VERSION = "0.2.4"
 end

--- a/spec/unit/container_control_spec.rb
+++ b/spec/unit/container_control_spec.rb
@@ -44,6 +44,8 @@ module Cutlass
           expect(response.status).to eq(200)
 
           expect(container.get_file_contents("foo.txt").strip).to eq("lol")
+
+          expect(container.logs.stderr).to include("POST /?payload=#{payload} HTTP/1.1")
         end
 
         ContainerBoot.new(image_id: image.id, expose_ports: [8080], memory: 1e9).call do |container|


### PR DESCRIPTION
When sending requests to containers it is important that we not just verify the input and output, but also that logging works as expected.

By exposing the contents of the container stdout and stderr we allow developers to assert against these contents.